### PR TITLE
Get x axes output as float

### DIFF
--- a/examples/LSM6DSR_I2C_HelloWorld/LSM6DSR_I2C_HelloWorld.ino
+++ b/examples/LSM6DSR_I2C_HelloWorld/LSM6DSR_I2C_HelloWorld.ino
@@ -88,7 +88,7 @@ void loop() {
   delay(250);
 
   // Read accelerometer and gyroscope.
-  int32_t accelerometer[3];
+  int32_t accelerometer[3]; // Alternatively, use float accelerometer[3]
   int32_t gyroscope[3];
   AccGyr.Get_X_Axes(accelerometer);
   AccGyr.Get_G_Axes(gyroscope);

--- a/examples/LSM6DSR_SPI_HelloWorld/LSM6DSR_SPI_HelloWorld.ino
+++ b/examples/LSM6DSR_SPI_HelloWorld/LSM6DSR_SPI_HelloWorld.ino
@@ -74,7 +74,7 @@ void loop() {
   delay(250);
 
   // Read accelerometer and gyroscope.
-  int32_t accelerometer[3];
+  int32_t accelerometer[3]; // Alternatively, use float accelerometer[3]
   int32_t gyroscope[3];
   AccGyr.Get_X_Axes(accelerometer);
   AccGyr.Get_G_Axes(gyroscope);

--- a/src/LSM6DSRSensor.cpp
+++ b/src/LSM6DSRSensor.cpp
@@ -631,6 +631,37 @@ LSM6DSRStatusTypeDef LSM6DSRSensor::Get_X_Axes(int32_t *Acceleration)
 
 
 /**
+ * @brief  Get the LSM6DSR accelerometer sensor axes as floats
+ * @param  Acceleration pointer where the values of the axes are written
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSRStatusTypeDef LSM6DSRSensor::Get_X_Axes(float *Acceleration)
+{
+  axis3bit16_t data_raw;
+  float sensitivity = 0.0f;
+
+  /* Read raw data values. */
+  if (lsm6dsr_acceleration_raw_get(&reg_ctx, data_raw.u8bit) != LSM6DSR_OK)
+  {
+    return LSM6DSR_ERROR;
+  }
+
+  /* Get LSM6DSR actual sensitivity. */
+  if (Get_X_Sensitivity(&sensitivity) != LSM6DSR_OK)
+  {
+    return LSM6DSR_ERROR;
+  }
+
+  /* Calculate the data. */
+  Acceleration[0] = ((float)((float)data_raw.i16bit[0] * sensitivity));
+  Acceleration[1] = ((float)((float)data_raw.i16bit[1] * sensitivity));
+  Acceleration[2] = ((float)((float)data_raw.i16bit[2] * sensitivity));
+
+  return LSM6DSR_OK;
+}
+
+
+/**
  * @brief  Get the LSM6DSR ACC data ready bit value
  * @param  Status the status of data ready bit
  * @retval 0 in case of success, an error code otherwise

--- a/src/LSM6DSRSensor.h
+++ b/src/LSM6DSRSensor.h
@@ -108,6 +108,7 @@ class LSM6DSRSensor
     LSM6DSRStatusTypeDef Set_X_FS(int32_t FullScale);
     LSM6DSRStatusTypeDef Get_X_AxesRaw(int16_t *Value);
     LSM6DSRStatusTypeDef Get_X_Axes(int32_t *Acceleration);
+    LSM6DSRStatusTypeDef Get_X_Axes(float *Acceleration);
     LSM6DSRStatusTypeDef Get_X_DRDY_Status(uint8_t *Status);
     
     LSM6DSRStatusTypeDef Enable_G();


### PR DESCRIPTION
**Summary**

LSM6DSR has a relatively high sensitivity of the accelerometer readings per the datasheet (0.061 mg/LSB at ±2 g FS). I think it would be useful for the output of the `Get_X_Axes` function to be a float (currently int32_t), so that it can be printed with more decimal points more easily.

This PR fixes/implements the following:

* change of the returned type of `Get_X_Axes` in `LSM6DSRSensor.cpp` and `LSM6DSRSensor.h`
* change of the type of the accelerometer[3] variable in both arudino examples

**Motivation for making the change**

It would be especially convenient for use cases where high accuracy of the output is needed (i.e. machine monitoring systems), as well as for determining the actual sensitivity of the accelerometer in real life conditions. 

**Validation**

The changes have been validated using the example arduino sketches and an ESP32 (LOLIN D32 PRO in particular) with the LSM6DSR accelerometer.
